### PR TITLE
Basic Unit Summoning / Minor Card Positioning Fixes

### DIFF
--- a/Assets/_Project/Scripts/BenchManager.cs
+++ b/Assets/_Project/Scripts/BenchManager.cs
@@ -11,6 +11,7 @@ public class BenchManager : MonoBehaviour
 
     private Transform[] benchSlots;
     private UnitData[] occupiedSlots;
+    private UnitInstance[] occupiedInstances;
 
     public Transform gridCenter;
 
@@ -31,6 +32,7 @@ public class BenchManager : MonoBehaviour
     {
         benchSlots = new Transform[benchSlotCount];
         occupiedSlots = new UnitData[benchSlotCount];
+        occupiedInstances = new UnitInstance[benchSlotCount];
 
         float totalWidth = (benchSlotCount - 1) * slotSpacing;
         float startX = -totalWidth / 2f;
@@ -53,7 +55,7 @@ public class BenchManager : MonoBehaviour
             if (occupiedSlots[i] == null)
             {
                 occupiedSlots[i] = unit;
-                SpawnUnit(unit, benchSlots[i]);
+                occupiedInstances[i] = SpawnUnit(unit, benchSlots[i]);
                 return true;
             }
         }
@@ -62,9 +64,42 @@ public class BenchManager : MonoBehaviour
         return false;
     }
 
-    void SpawnUnit(UnitData unit, Transform slot)
+    public bool CanAdd(UnitData unit)
     {
-        GameObject instance = Instantiate(unit.unitPrefab, slot.position, Quaternion.identity, slot);
-        instance.GetComponent<UnitInstance>()?.Init(unit);
+        // Check for empty slot
+        for (int i = 0; i < occupiedSlots.Length; i++)
+        {
+            if (occupiedSlots[i] == null)
+            {
+                return true;
+            }
+        }
+
+        // Bench full - check for potential merge (two level 1 units of same type)
+        int count = 0;
+        for (int i = 0; i < occupiedSlots.Length; i++)
+        {
+            if (occupiedSlots[i] == unit && occupiedInstances[i] != null && occupiedInstances[i].level == 1)
+            {
+                count++;
+                if (count >= 2)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    UnitInstance SpawnUnit(UnitData unit, Transform slot)
+    {
+        GameObject instanceObj = Instantiate(unit.unitPrefab, slot.position, Quaternion.identity, slot);
+        UnitInstance inst = instanceObj.GetComponent<UnitInstance>();
+        if (inst != null)
+        {
+            inst.Init(unit);
+        }
+        return inst;
     }
 }

--- a/Assets/_Project/Scripts/CardMotionController.cs
+++ b/Assets/_Project/Scripts/CardMotionController.cs
@@ -28,6 +28,10 @@ public class CardMotionController : MonoBehaviour
     [SerializeField, Tooltip("Distance the card will lower when another card is being dragged.")]
     private float loweredOffsetDist = 1.4f;
 
+    [Header("Playable Zone")]
+    [SerializeField, Tooltip("Forward drag percentage required to play the card.")]
+    private float playableThreshold = 0.9f;
+
     [Header("Wobble Settings")]
     [SerializeField, Tooltip("How much mouse movement affects wobble.")]
     private float wobbleSensitivity = 0.5f;
@@ -44,6 +48,8 @@ public class CardMotionController : MonoBehaviour
     private Vector3 dragStartMousePos;
     private Vector3 dragStartWorldPos;
     private Quaternion dragStartRotation;
+
+    private float lastVerticalProgress = 0f;
 
     private Vector2 wobbleAngle = Vector2.zero;
     private Vector2 wobbleVelocity = Vector2.zero;
@@ -112,6 +118,8 @@ public class CardMotionController : MonoBehaviour
         // Step 2: Add drag lift *on top* of hover
         dragStartWorldPos = hoverPos + liftDir * dragLiftDistance;
 
+        lastVerticalProgress = 0f;
+
         // Reset wobble
         wobbleAngle = Vector2.zero;
         wobbleVelocity = Vector2.zero;
@@ -134,10 +142,11 @@ public class CardMotionController : MonoBehaviour
 
         UpdateWobble(mouseDelta, state.IsDragging);
 
-        float verticalProgress = GetVerticalDragProgress(currentMousePos);
+        // float verticalProgress = GetVerticalDragProgress(currentMousePos);
+        lastVerticalProgress = GetVerticalDragProgress(currentMousePos);
         float horizontalProgress = GetHorizontalDragProgress(currentMousePos);
 
-        ApplyDragTransform(verticalProgress, horizontalProgress);
+        ApplyDragTransform(lastVerticalProgress, horizontalProgress);
         // Optional:
         // if (percentDragged > 0.8f) ShowPlayPreview();
     }
@@ -216,6 +225,10 @@ public class CardMotionController : MonoBehaviour
     {
         EndDrag();
         state.IsDragging = false;
-        // TODO: add drop logic or snap back to arc
+
+        if (lastVerticalProgress >= playableThreshold)
+        {
+            deckManager?.PlayCard(gameObject);
+        }
     }
 }


### PR DESCRIPTION
Units are summonable. Dragging a card ~90% forward will put it in the summon zone. Letting go of drag in this area results in the card going through an assortment of 'summon checks' such as if the player has enough gold or whether there is enough space on the bench currently. There are preemptive checks for if a 'merge' is possible in the event that the bench is full, however more work is needed in this area.

Card positioning has been updated for when the hand is a smaller size than the starting hand. For example, with 5 cards in the hand, they are fanned out with certain offsets based on their hand position. When the player plays cards, their hand shrinks in quantity. A 'sizeScale' value is calculated and is multiplied against all offset values, so that the resulting smaller hand is positioned similarly (just with less cards).

In addition, hand generation now instantiates cards under the camera for a cleaner feel.