### PR TITLE
Add standup/sitdown hand behavior with gizmo

### DIFF
--- a/Assets/_Project/Scripts/CardMotionController.cs
+++ b/Assets/_Project/Scripts/CardMotionController.cs
@@ -84,7 +84,7 @@ public class CardMotionController : MonoBehaviour
         {
             // Card's thin axis (downward from the face)
             Vector3 loweredOffset = -transform.forward * loweredOffsetDist;
-            targetPos += loweredOffset * loweredOffsetDist;
+            targetPos += loweredOffset;
         }
 
         transform.position = Vector3.Lerp(transform.position, targetPos, Time.deltaTime * hoverLerpSpeed); // returnSpeed ~5–10
@@ -204,7 +204,12 @@ public class CardMotionController : MonoBehaviour
     
     private void OnMouseEnter()
     {
-        if (deckManager != null ? !deckManager.IsCardBeingDragged(gameObject) : true)
+        bool canHover = true;
+        if (deckManager != null)
+        {
+            canHover = !deckManager.IsCardBeingDragged(gameObject) && !deckManager.IsHandLowered();
+        }
+        if (canHover)
         {
             state.IsHovering = true;
         }

--- a/Assets/_Project/Scripts/DeckManager.cs
+++ b/Assets/_Project/Scripts/DeckManager.cs
@@ -107,6 +107,11 @@ public class DeckManager : MonoBehaviour
         return false;
     }
 
+    public bool IsHandLowered()
+    {
+        return cardHandDisplayer != null && cardHandDisplayer.HandIsLowered;
+    }
+
     public void GenerateHand()
     {
         ClearHand();


### PR DESCRIPTION
## Summary
- add screen boundary calculation for hand and paddings
- show optional gizmo for standup/sitdown boundary
- lower cards when cursor leaves the hand
- prevent hovering when the whole hand is lowered
- fix lowered offset calculation

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684723ced49c8322805862087c5e8319