### PR TITLE
Implement settings page state management

### DIFF
--- a/Assets/UserChoices.choices
+++ b/Assets/UserChoices.choices
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18cde282a8d045bf9d245fdcfaa7271b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  QuestionnaireVersion: 1.3
+  UserAnswers:
+    Answers:
+    - QuestionId: Pace
+      Answers:
+      - Slow
+    - QuestionId: Cheating
+      Answers:
+      - CheatingImportant
+    - QuestionId: CostSensitivity
+      Answers:
+      - NoCost
+    - QuestionId: NetcodeArchitecture
+      Answers:
+      - LockstepSimulation
+    - QuestionId: PlayerCount
+      Answers:
+      - 64+
+  Preset: 5
+  SelectedSolutions:
+    SelectedHostingModel: 1
+    SelectedNetcodeSolution: 3

--- a/Assets/UserChoices.choices.meta
+++ b/Assets/UserChoices.choices.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 61735aa9289e90d4b9b0ddd5c7216c4b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scenes/BattleTest.unity
+++ b/Assets/_Project/Scenes/BattleTest.unity
@@ -334,6 +334,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &265417075
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 265417077}
+  - component: {fileID: 265417076}
+  m_Layer: 0
+  m_Name: SettingsManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &265417076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 265417075}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 28a58884e8b14ed4f985a7ac0aa69b53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &265417077
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 265417075}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 736.22565, y: 426.04147, z: -37.25588}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &281150279
 GameObject:
   m_ObjectHideFlags: 0
@@ -1030,6 +1074,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb21f2bb2610cc0448d5a02add7cf90c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  GameSettingsManager: {fileID: 265417076}
   InGameMenuContainer: {fileID: 9197481963319205126, guid: 6cd1669432d0d8443868189027a75c04, type: 3}
 --- !u!4 &763311959
 Transform:
@@ -2022,3 +2067,4 @@ SceneRoots:
   - {fileID: 641969852}
   - {fileID: 763311959}
   - {fileID: 1456793928364793965}
+  - {fileID: 265417077}

--- a/Assets/_Project/Scripts/Core/GameSettingsData.cs
+++ b/Assets/_Project/Scripts/Core/GameSettingsData.cs
@@ -1,0 +1,13 @@
+using GameSettings;
+
+[System.Serializable]
+public class GameSettingsData
+{
+    public ResolutionSetting screenResolution;
+    public ScreenModeSetting screenMode;
+    public GraphicsQuality overallGraphicsQuality;
+    public float masterVolume;
+    public float musicVolume;
+    public float sfxVolume;
+    public float voiceVolume;
+}

--- a/Assets/_Project/Scripts/Core/GameSettingsData.cs.meta
+++ b/Assets/_Project/Scripts/Core/GameSettingsData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6f3d1c6136bb58468c50801ef3fff03

--- a/Assets/_Project/Scripts/Core/GameSettingsEnums.cs
+++ b/Assets/_Project/Scripts/Core/GameSettingsEnums.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GameSettings
+{
+    public enum ResolutionSetting
+    {
+        _1024x768,
+        _1280x720,
+        _1600x900,
+        _1920x1080,
+        _2560x1440,
+        _3840x2160
+    }
+
+    public static class ResolutionSettingExtensions
+    {
+        public static string ToResolutionString(this ResolutionSetting res)
+        {
+            return res switch
+            {
+                ResolutionSetting._1024x768 => "1024x768",
+                ResolutionSetting._1280x720 => "1280x720",
+                ResolutionSetting._1600x900 => "1600x900",
+                ResolutionSetting._1920x1080 => "1920x1080",
+                ResolutionSetting._2560x1440 => "2560x1440",
+                ResolutionSetting._3840x2160 => "3840x2160",
+                _ => "Unknown"
+            };
+        }
+
+        public static ResolutionSetting ToResolutionSetting(string resolutionString)
+        {
+            return resolutionString switch
+            {
+                "1024x768" => ResolutionSetting._1024x768,
+                "1280x720" => ResolutionSetting._1280x720,
+                "1600x900" => ResolutionSetting._1600x900,
+                "1920x1080" => ResolutionSetting._1920x1080,
+                "2560x1440" => ResolutionSetting._2560x1440,
+                "3840x2160" => ResolutionSetting._3840x2160,
+                _ => ResolutionSetting._1920x1080 // Default to 1920x1080 if incorrect value is provided
+            };
+        }
+
+        public static Vector2Int GetDimensions(this ResolutionSetting res)
+        {
+            return res switch
+            {
+                ResolutionSetting._1024x768 => new Vector2Int(1024, 768),
+                ResolutionSetting._1280x720 => new Vector2Int(1280, 720),
+                ResolutionSetting._1600x900 => new Vector2Int(1600, 900),
+                ResolutionSetting._1920x1080 => new Vector2Int(1920, 1080),
+                ResolutionSetting._2560x1440 => new Vector2Int(2560, 1440),
+                ResolutionSetting._3840x2160 => new Vector2Int(3840, 2160),
+                _ => new Vector2Int(1920, 1080),
+            };
+        }
+
+        public static List<string> GetResolutionList()
+        {
+            List<string> result = new List<string>();
+            foreach (ResolutionSetting res in Enum.GetValues(typeof(ResolutionSetting)))
+            {
+                result.Add(ToResolutionString(res));
+            }
+            return result;
+        }
+    }
+
+    public enum ScreenModeSetting
+    {
+        Fullscreen,
+        BorderlessWindow,
+        Windowed
+    }
+
+    public static class ScreenModeSettingExtensions
+    {
+        public static string ToScreenModeString(this ScreenModeSetting res)
+        {
+            return res switch
+            {
+                ScreenModeSetting.Fullscreen => "Fullscreen",
+                ScreenModeSetting.BorderlessWindow => "Borderless Window",
+                ScreenModeSetting.Windowed => "Windowed",
+                _ => "Unknown"
+            };
+        }
+
+        public static ScreenModeSetting ToScreenModeSetting(string screenModeString)
+        {
+            return screenModeString switch
+            {
+                "Fullscreen" => ScreenModeSetting.Fullscreen,
+                "Borderless Window" => ScreenModeSetting.BorderlessWindow,
+                "Windowed" => ScreenModeSetting.Windowed,
+                _ => ScreenModeSetting.Fullscreen // Default to Fullscreen if incorrect value is provided
+            };
+        }
+
+        public static List<string> GetScreenModeList()
+        {
+            List<string> result = new List<string>();
+            foreach (ScreenModeSetting res in Enum.GetValues(typeof(ScreenModeSetting)))
+            {
+                result.Add(ToScreenModeString(res));
+            }
+            return result;
+        }
+    }
+
+    public enum GraphicsQuality
+    {
+        Low,
+        Medium,
+        High,
+        Ultra
+    }
+}

--- a/Assets/_Project/Scripts/Core/GameSettingsEnums.cs.meta
+++ b/Assets/_Project/Scripts/Core/GameSettingsEnums.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca563d86a45b66f41a35be924b10fd9c

--- a/Assets/_Project/Scripts/Core/GameSettingsManager.cs
+++ b/Assets/_Project/Scripts/Core/GameSettingsManager.cs
@@ -1,0 +1,141 @@
+using UnityEngine;
+using GameSettings;
+using System.IO;
+using System;
+using UnityEngine.Rendering;
+
+public class GameSettingsManager : MonoBehaviour
+{
+    private static readonly string SettingsFileName = "settings.json";
+    private string SettingsFilePath => Path.Combine(Application.persistentDataPath, SettingsFileName);
+
+    public static GameSettingsManager Instance { get; private set; }
+
+    /* VIDEO OPTIONS */
+    public ResolutionSetting ScreenResolution { get; private set; }
+    public ScreenModeSetting ScreenMode { get; private set; }
+
+    /* AUDIO OPTIONS */
+    public float MasterVolume { get; private set; }
+    public float MusicVolume { get; private set; }
+    public float SFXVolume { get; private set; }
+    public float VoiceVolume { get; private set; }
+
+    /* GRAPHICS OPTIONS */
+    public GraphicsQuality OverallGraphicsQuality { get; private set; }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        LoadSettings();
+    }
+
+    private void SaveSettings()
+    {
+        var data = new GameSettingsData
+        {
+            screenResolution = ScreenResolution,
+            screenMode = ScreenMode,
+            overallGraphicsQuality = OverallGraphicsQuality,
+            masterVolume = MasterVolume,
+            musicVolume = MusicVolume,
+            sfxVolume = SFXVolume,
+            voiceVolume = VoiceVolume,
+        };
+        string json = JsonUtility.ToJson(data, true);
+        File.WriteAllText(SettingsFilePath, json);
+    }
+
+    private void LoadSettings()
+    {
+        Debug.Log($"Settings file path: {SettingsFilePath}");
+        if (File.Exists(SettingsFilePath))
+        {
+            try
+            {
+                string json = File.ReadAllText(SettingsFilePath);
+                var data = JsonUtility.FromJson<GameSettingsData>(json);
+                Debug.Log($"Settings JSON: {json}");
+
+                ScreenResolution = data.screenResolution;
+                ScreenMode = data.screenMode;
+                OverallGraphicsQuality = data.overallGraphicsQuality;
+                MasterVolume = data.masterVolume;
+                MusicVolume = data.musicVolume;
+                SFXVolume = data.sfxVolume;
+                VoiceVolume = data.voiceVolume;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Failed to load settings. Using defaults. Reason: {e.Message}");
+                SetDefaults();
+            }
+        }
+        else
+        {
+            // Settings should take default values if settings file doesn't exist.
+            SetDefaults();
+        }
+    }
+
+    private void SetDefaults()
+    {
+        ScreenResolution = ResolutionSetting._1920x1080; // TODO: Detect appropriate screen resolution?
+        ScreenMode = ScreenModeSetting.Fullscreen;
+        OverallGraphicsQuality = GraphicsQuality.High; // TODO: Detect appropriate graphics quality?
+        MasterVolume = 1f;
+        MusicVolume = 1f;
+        SFXVolume = 1f;
+        VoiceVolume = 1f;
+        SaveSettings();
+    }
+
+    public void SetScreenResolution(ResolutionSetting res)
+    {
+        ScreenResolution = res;
+        SaveSettings();
+    }
+
+    public void SetScreenMode(ScreenModeSetting mode)
+    {
+        ScreenMode = mode;
+        SaveSettings();
+    }
+
+    public void SetMasterVolume(float volume)
+    {
+        MasterVolume = Mathf.Clamp01(volume);
+        SaveSettings();
+    }
+
+    public void SetMusicVolume(float volume)
+    {
+        MusicVolume = Mathf.Clamp01(volume);
+        SaveSettings();
+    }
+
+    public void SetSFXVolume(float volume)
+    {
+        SFXVolume = Mathf.Clamp01(volume);
+        SaveSettings();
+    }
+
+    public void SetVoiceVolume(float volume)
+    {
+        VoiceVolume = Mathf.Clamp01(volume);
+        SaveSettings();
+    }
+
+    public void SetOverallGraphicsQuality(GraphicsQuality quality)
+    {
+        OverallGraphicsQuality = quality;
+        SaveSettings();
+    }
+}

--- a/Assets/_Project/Scripts/Core/GameSettingsManager.cs.meta
+++ b/Assets/_Project/Scripts/Core/GameSettingsManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 28a58884e8b14ed4f985a7ac0aa69b53

--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -159,6 +159,9 @@ public class GroupContainerMenuItem : IMenuItem, ISettingsPage
 
     public void OnClick(VisualElement parentLayer, VisualElement nextLayer, int tier)
     {
+        if (activePage == this)
+            return;
+
         void BuildPage()
         {
             nextLayer.Clear();
@@ -318,6 +321,7 @@ public static class UIUtils
         }
 
         // Remove layers at or beyond targetIndex
+        int removedCount = parent.childCount - targetIndex;
         for (int i = parent.childCount - 1; i >= targetIndex; i--)
         {
             var layerToRemove = parent[i];
@@ -332,12 +336,15 @@ public static class UIUtils
         var layer = new VisualElement();
         layer.AddToClassList("menu-column");
         layer.AddToClassList($"tier{tier}-layer");
+        layer.style.display = DisplayStyle.None;
         parent.Add(layer);
 
-        // Animate
+        // Animate after fade-out completes
+        int delay = removedCount > 0 ? 300 : 10;
         layer.schedule.Execute(() => {
+            layer.style.display = DisplayStyle.Flex;
             layer.AddToClassList("active");
-        }).ExecuteLater(10);
+        }).ExecuteLater(delay);
 
         return layer;
     }

--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -100,7 +100,7 @@ public class GroupContainerMenuItem : IMenuItem, ISettingsPage
     public string Label { get; }
     public string StyleClass { get; }
 
-    private readonly List<ISettingItem> settings;
+    private readonly List<ISettingItem> _settings;
     private static ModalManager modal;
     private static GroupContainerMenuItem activePage;
     private bool dirty;
@@ -140,14 +140,14 @@ public class GroupContainerMenuItem : IMenuItem, ISettingsPage
     public GroupContainerMenuItem(string label, string styleClass = null, params ISettingItem[] settings)
     {
         Label = label;
-        this.settings = new List<ISettingItem>(settings);
+        _settings = new List<ISettingItem>(settings);
         StyleClass = styleClass;
     }
 
     public VisualElement Build()
     {
         var root = new VisualElement();
-        foreach (var setting in settings)
+        foreach (var setting in _settings)
         {
             root.Add(setting.Build());
         }

--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -23,6 +23,10 @@ public interface ISettingsPage
     VisualElement Build();
 }
 
+/*
+    The submenu is a unique IMenuItem that renders a submenu of buttons, most commonly a GroupContainerMenuItem.
+    The 'onClick()' function is built in and cannot be specified.
+*/
 public class Submenu : IMenuItem
 {
     public string Label { get; }
@@ -337,6 +341,7 @@ public static class UIUtils
         layer.AddToClassList("menu-column");
         layer.AddToClassList($"tier{tier}-layer");
         layer.style.display = DisplayStyle.None;
+        layer.style.justifyContent = Justify.Center;
         parent.Add(layer);
 
         // Animate after fade-out completes

--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -318,9 +318,9 @@ public static class UIUtils
         }
 
         // Remove layers at or beyond targetIndex
-        while (parent.childCount > targetIndex)
+        for (int i = parent.childCount - 1; i >= targetIndex; i--)
         {
-            var layerToRemove = parent[parent.childCount - 1];
+            var layerToRemove = parent[i];
             layerToRemove.RemoveFromClassList("active");
             layerToRemove.schedule.Execute(() =>
             {

--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -71,18 +71,7 @@ public class Submenu : IMenuItem
         }
     }
 
-    public VisualElement Build()
-    {
-        var root = new VisualElement();
-        foreach (var setting in settings)
-        {
-            root.Add(setting.Build());
-        }
-        var apply = new Button(() => { Apply(); }) { text = "Apply" };
-        apply.AddToClassList("apply-button");
-        root.Add(apply);
-        return root;
-    }
+    // Submenu does not represent a settings page so no Build implementation
 }
 
 public class LeafMenuItem : IMenuItem
@@ -153,6 +142,19 @@ public class GroupContainerMenuItem : IMenuItem, ISettingsPage
         Label = label;
         this.settings = new List<ISettingItem>(settings);
         StyleClass = styleClass;
+    }
+
+    public VisualElement Build()
+    {
+        var root = new VisualElement();
+        foreach (var setting in settings)
+        {
+            root.Add(setting.Build());
+        }
+        var apply = new Button(() => { Apply(); }) { text = "Apply" };
+        apply.AddToClassList("apply-button");
+        root.Add(apply);
+        return root;
     }
 
     public void OnClick(VisualElement parentLayer, VisualElement nextLayer, int tier)

--- a/Assets/_Project/Scripts/UI/PauseMenuController.cs
+++ b/Assets/_Project/Scripts/UI/PauseMenuController.cs
@@ -27,6 +27,7 @@ public class PauseMenuController : MonoBehaviour
         cursor = mainCamera.GetComponent<HandleCursor>();
         uiBlocker = GetComponent<UIBlockerManager>();
         modal = GetComponent<ModalManager>();
+        GroupContainerMenuItem.SetModalManager(modal);
 
         var menuContainer = InGameMenuContainer.CloneTree();
         var root = rootDoc.rootVisualElement.Q<VisualElement>("ROOT");

--- a/Assets/_Project/Scripts/UI/PauseMenuController.cs
+++ b/Assets/_Project/Scripts/UI/PauseMenuController.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
+using GameSettings;
 
 public class PauseMenuController : MonoBehaviour
 {
+    public GameSettingsManager GameSettingsManager;
     public VisualTreeAsset InGameMenuContainer;
     private bool isPaused = false;
 
@@ -32,8 +34,7 @@ public class PauseMenuController : MonoBehaviour
         var menuContainer = InGameMenuContainer.CloneTree();
         var root = rootDoc.rootVisualElement.Q<VisualElement>("ROOT");
 
-        var nextLayer = menuContainer.Q<VisualElement>("nextLayer");
-        var primaryLayer = menuContainer.Q<VisualElement>("primary-layer");
+        var elementContent = menuContainer.Q<VisualElement>("ui-element-content");
         root.Add(menuContainer);
 
         var rootMenu = new List<IMenuItem>
@@ -41,12 +42,48 @@ public class PauseMenuController : MonoBehaviour
             new LeafMenuItem("Resume", ResumeGame),
             new Submenu("Settings", "tier1-button",
                 new GroupContainerMenuItem("Audio", "",
-                    new SliderSetting("Master Volume", 0f, 100f, 50f, v => Debug.Log("Master Volume: " + v)),
-                    new SliderSetting("Music Volume", 0f, 100f, 70f, v => Debug.Log("Music Volume: " + v))
+                    new SliderSetting("Master Volume", 0f, 100f, GameSettingsManager.MasterVolume*100,
+                        v =>
+                        {
+                            Debug.Log("Master Volume: " + v + " " + v/100);
+                            GameSettingsManager.SetMasterVolume(v/100);
+                        }),
+                    new SliderSetting("Music Volume", 0f, 100f, GameSettingsManager.MusicVolume*100,
+                        v =>
+                        {
+                            Debug.Log("Music Volume: " + v + " " + v/100);
+                            GameSettingsManager.SetMusicVolume(v/100);
+                        }),
+                    new SliderSetting("SFX Volume", 0f, 100f, GameSettingsManager.SFXVolume*100,
+                        v =>
+                        {
+                            Debug.Log("SFX Volume: " + v + " " + v/100);
+                            GameSettingsManager.SetSFXVolume(v/100);
+                        }),
+                    new SliderSetting("Voice Volume", 0f, 100f, GameSettingsManager.VoiceVolume*100,
+                        v =>
+                        {
+                            Debug.Log("Voice Volume: " + v + " " + v/100);
+                            GameSettingsManager.SetVoiceVolume(v/100);
+                        })
                 ),
                 new GroupContainerMenuItem("Video", "",
-                    new DropdownSetting("Resolution", new List<string> { "1920x1080", "1280x720" }, "1920x1080", val => Debug.Log("Res: " + val)),
-                    new ToggleSetting("Fullscreen", true, b => Debug.Log("Fullscreen: " + b))
+                    new DropdownSetting(
+                        "Resolution",
+                        ResolutionSettingExtensions.GetResolutionList(),
+                        ResolutionSettingExtensions.ToResolutionString(GameSettingsManager.ScreenResolution),
+                        val => {
+                            Debug.Log("ScreenResolution: " + val);
+                            GameSettingsManager.SetScreenResolution(ResolutionSettingExtensions.ToResolutionSetting(val));
+                        }),
+                    new DropdownSetting(
+                        "Screen Mode",
+                        ScreenModeSettingExtensions.GetScreenModeList(),
+                        ScreenModeSettingExtensions.ToScreenModeString(GameSettingsManager.ScreenMode),
+                        val => {
+                            Debug.Log("ScreenMode: " + val);
+                            GameSettingsManager.SetScreenMode(ScreenModeSettingExtensions.ToScreenModeSetting(val));
+                        })
                 ),
                 new GroupContainerMenuItem("Gameplay", "",
                     new ToggleSetting("<filler option gameplay>", true, b => Debug.Log("Useless: " + b))
@@ -61,6 +98,23 @@ public class PauseMenuController : MonoBehaviour
             new Submenu("Debug",
                 new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
             ),
+            new Submenu("test1",
+                new Submenu("test2",
+                    new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
+                ),
+                new Submenu("test3",
+                    new Submenu("test5",
+                        new Submenu("test6",
+                            new Submenu("test7",
+                                new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
+                            )
+                        )
+                    )
+                ),
+                new Submenu("test4",
+                    new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
+                )
+            ),
             new LeafMenuItem("Quit Game", HandleQuit)
         };
 
@@ -68,8 +122,8 @@ public class PauseMenuController : MonoBehaviour
         {
             var btn = new Button(() =>
             {
-                var nextLayer = UIUtils.CreateOrGetLayerColumn(primaryLayer, 2);
-                item.OnClick(primaryLayer, nextLayer, 2);
+                var nextLayer = UIUtils.CreateOrGetLayerColumn(elementContent, 2);
+                item.OnClick(elementContent, nextLayer, 2);
             })
             { text = item.Label };
 
@@ -79,7 +133,7 @@ public class PauseMenuController : MonoBehaviour
             if (!string.IsNullOrEmpty(item.StyleClass))
                 btn.AddToClassList(item.StyleClass);
 
-            primaryLayer.Add(btn);
+            elementContent.Add(btn);
         }
     }
 

--- a/Assets/_Project/Scripts/UI/USS/Layouts.uss
+++ b/Assets/_Project/Scripts/UI/USS/Layouts.uss
@@ -85,9 +85,8 @@
 /* ScrollView style for group containers */
 .settings-scroll {
     padding: 6px;
-    border-left-width: 1px;
+    border-left-width: 0px;
     border-left-color: #555;
-    row-gap: 4px;
 }
 
 .apply-button {
@@ -101,12 +100,12 @@
 }
 
 .tier2-layer {
-    background-color: #1a1a1a;
+    background-color:rgb(122, 44, 44);
 }
 
 .tier3-layer {
     background-color: #111;
-    border-left-width: 1px;
+    border-left-width: 0px;
     border-left-color: #555;
 }
 

--- a/Assets/_Project/Scripts/UI/USS/Layouts.uss
+++ b/Assets/_Project/Scripts/UI/USS/Layouts.uss
@@ -76,7 +76,10 @@
 /* Settings controls (optional) */
 .setting-control {
     font-size: 12px;
-    padding: 4px;
+    padding: 6px;
+    margin-bottom: 4px;
+    background-color: #333;
+    border-radius: 4px;
 }
 
 /* ScrollView style for group containers */
@@ -84,6 +87,12 @@
     padding: 6px;
     border-left-width: 1px;
     border-left-color: #555;
+    row-gap: 4px;
+}
+
+.apply-button {
+    margin-top: 8px;
+    align-self: flex-end;
 }
 
 /* Tier-specific layers */

--- a/Assets/_Project/Scripts/UI/UXML/InGameMenuContainer.uxml
+++ b/Assets/_Project/Scripts/UI/UXML/InGameMenuContainer.uxml
@@ -1,7 +1,6 @@
 <engine:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:engine="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/_Project/Scripts/UI/USS/Layouts.uss?fileID=7433441132597879392&amp;guid=b7bf865ee983f6b4bbb5f82f4f755a82&amp;type=3#Layouts" />
     <engine:VisualElement name="pause-root" style="flex-grow: 1; flex-direction: row; background-color: rgba(171, 236, 153, 0.44); flex-shrink: 1; flex-basis: auto; background-size: 100% 100%;">
-        <engine:VisualElement name="primary-layer" class="column-left" style="flex-grow: 0; flex-shrink: 0; justify-content: center; align-items: flex-start; align-content: center; background-color: rgba(183, 60, 60, 0.59);" />
-        <engine:VisualElement name="nextLayer" class="column-right" style="flex-grow: 1; flex-basis: 100%;" />
+        <engine:VisualElement name="ui-element-content" class="column-left" style="flex-grow: 0; flex-shrink: 0; justify-content: center; align-items: flex-start; align-content: center; background-color: rgba(183, 60, 60, 0.59); align-self: auto;" />
     </engine:VisualElement>
 </engine:UXML>

--- a/ProjectSettings/TimelineSettings.asset
+++ b/ProjectSettings/TimelineSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a287be6c49135cd4f9b2b8666c39d999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetDefaultFramerate: 60
+  m_DefaultFrameRate: 60

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 
 This game is currently in active development. Art, networking, and balance are in progress. Feedback and playtesting will guide ongoing iteration.
 
+### UI Setup
+
+The pause menu relies on `ModalManager` and `GroupContainerMenuItem` for settings pages.
+Attach a `ModalManager` component to the same GameObject as `PauseMenuController`.
+When navigating away from a settings page that has unsaved changes, a confirmation dialog will appear allowing you to apply or discard the modifications.
+
 ---
 
 *For concept art, development logs, and updates, stay tuned to future dev posts or repositories linked here.*


### PR DESCRIPTION
## Summary
- add `ISettingsPage` and expand `GroupContainerMenuItem`
- mark settings dirty on change and show confirmation when leaving pages
- fade UI columns out when navigating back
- hook modal manager in pause menu
- improve styles for settings controls
- document UI setup in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a3c675a48322ad158188bf985e21