### PR TITLE
Track menu stack in pause menu

### DIFF
--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -94,12 +94,12 @@ public class LeafMenuItem : IMenuItem
 
     public void OnClick(VisualElement parentLayer, VisualElement nextLayer, int tier)
     {
-        var layer = PauseMenuController.Instance.TryOpen(this, parentLayer, tier);
-        if (layer == null)
-            return;
+        System.Action run = () => { onClickAction?.Invoke(); };
 
-        layer.Clear();
-        onClickAction?.Invoke();
+        if (GroupContainerMenuItem.ActivePageHasPending)
+            GroupContainerMenuItem.ShowUnsavedPrompt(run);
+        else
+            run();
     }
 }
 

--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -344,6 +344,8 @@ public static class UIUtils
         layer.style.justifyContent = Justify.Center;
         parent.Add(layer);
 
+        AdjustColumnFlex(parent);
+
         // Animate after fade-out completes
         int delay = removedCount > 0 ? 300 : 10;
         layer.schedule.Execute(() => {
@@ -352,5 +354,16 @@ public static class UIUtils
         }).ExecuteLater(delay);
 
         return layer;
+    }
+
+    public static void AdjustColumnFlex(VisualElement container)
+    {
+        int count = container.childCount;
+        for (int i = 0; i < count; i++)
+        {
+            var child = container[i];
+            child.style.flexGrow = i == count - 1 ? 1f : 0f;
+            child.style.flexShrink = 0f;
+        }
     }
 }

--- a/Assets/_Project/Scripts/UI/InterfaceElements.cs
+++ b/Assets/_Project/Scripts/UI/InterfaceElements.cs
@@ -5,6 +5,7 @@ using UnityEngine.UIElements;
 
 public interface IMenuItem
 {
+    string Id { get; }
     string Label { get; }
     string StyleClass { get; }
     void OnClick(VisualElement parentLayer, VisualElement nextLayer, int tier);
@@ -29,16 +30,18 @@ public interface ISettingsPage
 */
 public class Submenu : IMenuItem
 {
+    public string Id { get; }
     public string Label { get; }
     public string StyleClass { get; }
 
     public List<IMenuItem> Children { get; }
 
-    public Submenu(string label, params IMenuItem[] children)
-        : this(label, null, children) { }
+    public Submenu(string id, string label, params IMenuItem[] children)
+        : this(id, label, null, children) { }
 
-    public Submenu(string label, string styleClass, params IMenuItem[] children)
+    public Submenu(string id, string label, string styleClass, params IMenuItem[] children)
     {
+        Id = id;
         Label = label;
         StyleClass = styleClass;
         Children = new List<IMenuItem>(children);
@@ -46,22 +49,17 @@ public class Submenu : IMenuItem
 
     public void OnClick(VisualElement parentLayer, VisualElement nextLayer, int tier)
     {
-        nextLayer.Clear();
+        var layer = PauseMenuController.Instance.TryOpen(this, parentLayer, tier);
+        if (layer == null)
+            return;
+
+        layer.Clear();
 
         foreach (var child in Children)
         {
             var btn = new Button(() =>
             {
-                void OpenChild()
-                {
-                    var childNext = UIUtils.CreateOrGetLayerColumn(nextLayer, tier + 1);
-                    child.OnClick(nextLayer, childNext, tier + 1);
-                }
-
-                if (GroupContainerMenuItem.ActivePageHasPending)
-                    GroupContainerMenuItem.ShowUnsavedPrompt(OpenChild);
-                else
-                    OpenChild();
+                child.OnClick(layer, null, tier + 1);
             })
             { text = child.Label };
 
@@ -71,7 +69,7 @@ public class Submenu : IMenuItem
             if (!string.IsNullOrEmpty(child.StyleClass))
                 btn.AddToClassList(child.StyleClass);
 
-            nextLayer.Add(btn);
+            layer.Add(btn);
         }
     }
 
@@ -80,13 +78,15 @@ public class Submenu : IMenuItem
 
 public class LeafMenuItem : IMenuItem
 {
+    public string Id { get; }
     public string Label { get; }
     public string StyleClass { get; }
 
     private readonly System.Action onClickAction;
 
-    public LeafMenuItem(string label, System.Action onClick, string styleClass = null)
+    public LeafMenuItem(string id, string label, System.Action onClick, string styleClass = null)
     {
+        Id = id;
         Label = label;
         onClickAction = onClick;
         StyleClass = styleClass;
@@ -94,13 +94,18 @@ public class LeafMenuItem : IMenuItem
 
     public void OnClick(VisualElement parentLayer, VisualElement nextLayer, int tier)
     {
-        nextLayer.Clear();
+        var layer = PauseMenuController.Instance.TryOpen(this, parentLayer, tier);
+        if (layer == null)
+            return;
+
+        layer.Clear();
         onClickAction?.Invoke();
     }
 }
 
 public class GroupContainerMenuItem : IMenuItem, ISettingsPage
 {
+    public string Id { get; }
     public string Label { get; }
     public string StyleClass { get; }
 
@@ -135,14 +140,20 @@ public class GroupContainerMenuItem : IMenuItem, ISettingsPage
         modal = mgr;
     }
 
+    internal static void ClearActivePage()
+    {
+        activePage = null;
+    }
+
     internal static void NotifyChange()
     {
         if (activePage != null)
             activePage.dirty = true;
     }
 
-    public GroupContainerMenuItem(string label, string styleClass = null, params ISettingItem[] settings)
+    public GroupContainerMenuItem(string id, string label, string styleClass = null, params ISettingItem[] settings)
     {
+        Id = id;
         Label = label;
         _settings = new List<ISettingItem>(settings);
         StyleClass = styleClass;
@@ -163,32 +174,21 @@ public class GroupContainerMenuItem : IMenuItem, ISettingsPage
 
     public void OnClick(VisualElement parentLayer, VisualElement nextLayer, int tier)
     {
-        if (activePage == this)
+        var layer = PauseMenuController.Instance.TryOpen(this, parentLayer, tier);
+        if (layer == null)
             return;
 
-        void BuildPage()
-        {
-            nextLayer.Clear();
+        layer.Clear();
 
-            var scroll = new ScrollView();
-            scroll.AddToClassList("settings-scroll");
-            nextLayer.Add(scroll);
+        var scroll = new ScrollView();
+        scroll.AddToClassList("settings-scroll");
+        layer.Add(scroll);
 
-            var content = Build();
-            scroll.Add(content);
+        var content = Build();
+        scroll.Add(content);
 
-            activePage = this;
-            dirty = false;
-        }
-
-        if (activePage != null && activePage != this && activePage.HasPendingChanges)
-        {
-            ShowUnsavedPrompt(BuildPage);
-        }
-        else
-        {
-            BuildPage();
-        }
+        activePage = this;
+        dirty = false;
     }
 
     public bool HasPendingChanges => dirty;

--- a/Assets/_Project/Scripts/UI/PauseMenuController.cs
+++ b/Assets/_Project/Scripts/UI/PauseMenuController.cs
@@ -245,7 +245,6 @@ public class PauseMenuController : MonoBehaviour
 
             openLayers.Add(nextLayer);
             openItemIds.Add(item.Id);
-            UIUtils.AdjustColumnFlex(parent);
         };
 
         if (GroupContainerMenuItem.ActivePageHasPending)

--- a/Assets/_Project/Scripts/UI/PauseMenuController.cs
+++ b/Assets/_Project/Scripts/UI/PauseMenuController.cs
@@ -44,6 +44,7 @@ public class PauseMenuController : MonoBehaviour
 
         menuRoot = elementContent;
         openLayers.Add(menuRoot);
+        UIUtils.AdjustColumnFlex(menuRoot.parent);
 
         var rootMenu = new List<IMenuItem>
         {
@@ -244,6 +245,7 @@ public class PauseMenuController : MonoBehaviour
 
             openLayers.Add(nextLayer);
             openItemIds.Add(item.Id);
+            UIUtils.AdjustColumnFlex(parent);
         };
 
         if (GroupContainerMenuItem.ActivePageHasPending)
@@ -274,6 +276,8 @@ public class PauseMenuController : MonoBehaviour
                     parentContainer.Remove(layerToRemove);
                 }).ExecuteLater(300);
             }
+
+            UIUtils.AdjustColumnFlex(parentContainer);
 
             for (int i = openLayers.Count - 1; i >= tier - 1; i--)
             {

--- a/Assets/_Project/Scripts/UI/PauseMenuController.cs
+++ b/Assets/_Project/Scripts/UI/PauseMenuController.cs
@@ -5,6 +5,7 @@ using GameSettings;
 
 public class PauseMenuController : MonoBehaviour
 {
+    public static PauseMenuController Instance { get; private set; }
     public GameSettingsManager GameSettingsManager;
     public VisualTreeAsset InGameMenuContainer;
     private bool isPaused = false;
@@ -15,9 +16,13 @@ public class PauseMenuController : MonoBehaviour
     private UIBlockerManager uiBlocker;
     private ModalManager modal;
     private UIDocument rootDoc;
+    private VisualElement menuRoot;
+    private readonly List<string> openItemIds = new List<string>();
+    private readonly List<VisualElement> openLayers = new List<VisualElement>();
 
     void Awake()
     {
+        Instance = this;
         rootDoc = GetComponent<UIDocument>();
         if (rootDoc != null)
             rootDoc.rootVisualElement.style.display = DisplayStyle.None;
@@ -37,11 +42,14 @@ public class PauseMenuController : MonoBehaviour
         var elementContent = menuContainer.Q<VisualElement>("ui-element-content");
         root.Add(menuContainer);
 
+        menuRoot = elementContent;
+        openLayers.Add(menuRoot);
+
         var rootMenu = new List<IMenuItem>
         {
-            new LeafMenuItem("Resume", ResumeGame),
-            new Submenu("Settings", "tier1-button",
-                new GroupContainerMenuItem("Audio", "",
+            new LeafMenuItem("resume", "Resume", ResumeGame),
+            new Submenu("settings", "Settings", "tier1-button",
+                new GroupContainerMenuItem("audio", "Audio", "",
                     new SliderSetting("Master Volume", 0f, 100f, GameSettingsManager.MasterVolume*100,
                         v =>
                         {
@@ -67,7 +75,7 @@ public class PauseMenuController : MonoBehaviour
                             GameSettingsManager.SetVoiceVolume(v/100);
                         })
                 ),
-                new GroupContainerMenuItem("Video", "",
+                new GroupContainerMenuItem("video", "Video", "",
                     new DropdownSetting(
                         "Resolution",
                         ResolutionSettingExtensions.GetResolutionList(),
@@ -85,45 +93,44 @@ public class PauseMenuController : MonoBehaviour
                             GameSettingsManager.SetScreenMode(ScreenModeSettingExtensions.ToScreenModeSetting(val));
                         })
                 ),
-                new GroupContainerMenuItem("Gameplay", "",
+                new GroupContainerMenuItem("gameplay", "Gameplay", "",
                     new ToggleSetting("<filler option gameplay>", true, b => Debug.Log("Useless: " + b))
                 ),
-                new GroupContainerMenuItem("Controls", "",
+                new GroupContainerMenuItem("controls", "Controls", "",
                     new ToggleSetting("<filler option controls>", true, b => Debug.Log("Useless: " + b))
                 ),
-                new GroupContainerMenuItem("Misc", "",
+                new GroupContainerMenuItem("misc", "Misc", "",
                     new ToggleSetting("<filler option misc>", true, b => Debug.Log("Useless: " + b))
                 )
             ),
-            new Submenu("Debug",
-                new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
+            new Submenu("debug", "Debug",
+                new LeafMenuItem("matchmaking", "Enter matchmaking", HandleAttemptMatchmaking)
             ),
-            new Submenu("test1",
-                new Submenu("test2",
-                    new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
+            new Submenu("test1", "test1",
+                new Submenu("test2", "test2",
+                    new LeafMenuItem("test2-match", "Enter matchmaking", HandleAttemptMatchmaking)
                 ),
-                new Submenu("test3",
-                    new Submenu("test5",
-                        new Submenu("test6",
-                            new Submenu("test7",
-                                new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
+                new Submenu("test3", "test3",
+                    new Submenu("test5", "test5",
+                        new Submenu("test6", "test6",
+                            new Submenu("test7", "test7",
+                                new LeafMenuItem("test7-match", "Enter matchmaking", HandleAttemptMatchmaking)
                             )
                         )
                     )
                 ),
-                new Submenu("test4",
-                    new LeafMenuItem("Enter matchmaking", HandleAttemptMatchmaking)
+                new Submenu("test4", "test4",
+                    new LeafMenuItem("test4-match", "Enter matchmaking", HandleAttemptMatchmaking)
                 )
             ),
-            new LeafMenuItem("Quit Game", HandleQuit)
+            new LeafMenuItem("quit", "Quit Game", HandleQuit)
         };
 
         foreach (var item in rootMenu)
         {
             var btn = new Button(() =>
             {
-                var nextLayer = UIUtils.CreateOrGetLayerColumn(elementContent, 2);
-                item.OnClick(elementContent, nextLayer, 2);
+                item.OnClick(elementContent, null, 2);
             })
             { text = item.Label };
 
@@ -212,5 +219,74 @@ public class PauseMenuController : MonoBehaviour
             "Yes",
             "No"
         );
+    }
+
+    public VisualElement TryOpen(IMenuItem item, VisualElement parent, int tier)
+    {
+        VisualElement nextLayer = null;
+
+        if (openItemIds.Count >= tier && openItemIds[tier - 1] == item.Id)
+        {
+            CloseTier(tier);
+            return null;
+        }
+
+        System.Action openAction = () =>
+        {
+            GroupContainerMenuItem.ClearActivePage();
+            nextLayer = UIUtils.CreateOrGetLayerColumn(parent, tier);
+
+            while (openLayers.Count >= tier)
+            {
+                openLayers.RemoveAt(openLayers.Count - 1);
+                openItemIds.RemoveAt(openItemIds.Count - 1);
+            }
+
+            openLayers.Add(nextLayer);
+            openItemIds.Add(item.Id);
+        };
+
+        if (GroupContainerMenuItem.ActivePageHasPending)
+            GroupContainerMenuItem.ShowUnsavedPrompt(openAction);
+        else
+            openAction();
+
+        return nextLayer;
+    }
+
+    public void CloseTier(int tier)
+    {
+        if (tier <= 1 || openLayers.Count < tier)
+            return;
+
+        System.Action closeAction = () =>
+        {
+            var parent = openLayers[tier - 2];
+            var parentContainer = parent.parent;
+            int currentIndex = parentContainer.IndexOf(parent);
+            int targetIndex = currentIndex + 1;
+            for (int i = parentContainer.childCount - 1; i >= targetIndex; i--)
+            {
+                var layerToRemove = parentContainer[i];
+                layerToRemove.RemoveFromClassList("active");
+                layerToRemove.schedule.Execute(() =>
+                {
+                    parentContainer.Remove(layerToRemove);
+                }).ExecuteLater(300);
+            }
+
+            for (int i = openLayers.Count - 1; i >= tier - 1; i--)
+            {
+                openLayers.RemoveAt(i);
+                openItemIds.RemoveAt(i);
+            }
+
+            GroupContainerMenuItem.ClearActivePage();
+        };
+
+        if (GroupContainerMenuItem.ActivePageHasPending)
+            GroupContainerMenuItem.ShowUnsavedPrompt(closeAction);
+        else
+            closeAction();
     }
 }

--- a/Assets/_Project/Scripts/UI/PauseMenuController.cs
+++ b/Assets/_Project/Scripts/UI/PauseMenuController.cs
@@ -225,7 +225,7 @@ public class PauseMenuController : MonoBehaviour
     {
         VisualElement nextLayer = null;
 
-        if (openItemIds.Count >= tier && openItemIds[tier - 1] == item.Id)
+        if (openItemIds.Count >= tier - 1 && openItemIds[tier - 2] == item.Id)
         {
             CloseTier(tier);
             return null;
@@ -278,6 +278,9 @@ public class PauseMenuController : MonoBehaviour
             for (int i = openLayers.Count - 1; i >= tier - 1; i--)
             {
                 openLayers.RemoveAt(i);
+            }
+            for (int i = openItemIds.Count - 1; i >= tier - 2; i--)
+            {
                 openItemIds.RemoveAt(i);
             }
 

--- a/Assets/_Project/Scripts/UI/USS/Layouts.uss
+++ b/Assets/_Project/Scripts/UI/USS/Layouts.uss
@@ -113,6 +113,8 @@
     padding-left: 32px;
     opacity: 0;
     transition: opacity 0.3s ease;
+    flex-grow: 0;
+    flex-shrink: 0;
 }
 
 .menu-column.active {

--- a/Assets/_Project/Scripts/UI/USS/Layouts.uss
+++ b/Assets/_Project/Scripts/UI/USS/Layouts.uss
@@ -115,6 +115,8 @@
     transition: opacity 0.3s ease;
     flex-grow: 0;
     flex-shrink: 0;
+    justify-content: center;
+    align-items: flex-start;
 }
 
 .menu-column.active {


### PR DESCRIPTION
## Summary
- allow menu items to expose an `Id`
- track opened menu ids and layers inside `PauseMenuController`
- centralize opening/closing logic with `TryOpen` and `CloseTier`
- update UI menu item implementations to use controller methods

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855bdb8ca248322a44463d2659bffc7